### PR TITLE
Move deferred cleanup after the browser has launched

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,14 @@ module github.com/rusq/slackauth
 go 1.21.4
 
 require (
-	github.com/go-rod/rod v0.114.5
+	github.com/go-rod/rod v0.114.7
 	github.com/joho/godotenv v1.5.1
 )
 
 require (
 	github.com/ysmood/fetchup v0.2.4 // indirect
 	github.com/ysmood/goob v0.4.0 // indirect
-	github.com/ysmood/got v0.38.2 // indirect
+	github.com/ysmood/got v0.39.4 // indirect
 	github.com/ysmood/gson v0.7.3 // indirect
 	github.com/ysmood/leakless v0.8.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-rod/rod v0.114.5 h1:1x6oqnslwFVuXJbJifgxspJUd3O4ntaGhRLHt+4Er9c=
-github.com/go-rod/rod v0.114.5/go.mod h1:aiedSEFg5DwG/fnNbUOTPMTTWX3MRj6vIs/a684Mthw=
+github.com/go-rod/rod v0.114.7 h1:h4pimzSOUnw7Eo41zdJA788XsawzHjJMyzCE3BrBww0=
+github.com/go-rod/rod v0.114.7/go.mod h1:aiedSEFg5DwG/fnNbUOTPMTTWX3MRj6vIs/a684Mthw=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/ysmood/fetchup v0.2.3/go.mod h1:xhibcRKziSvol0H1/pj33dnKrYyI2ebIvz5cOOkYGns=
@@ -11,8 +11,8 @@ github.com/ysmood/gop v0.0.2/go.mod h1:rr5z2z27oGEbyB787hpEcx4ab8cCiPnKxn0SUHt6x
 github.com/ysmood/gop v0.2.0 h1:+tFrG0TWPxT6p9ZaZs+VY+opCvHU8/3Fk6BaNv6kqKg=
 github.com/ysmood/gop v0.2.0/go.mod h1:rr5z2z27oGEbyB787hpEcx4ab8cCiPnKxn0SUHt6xzk=
 github.com/ysmood/got v0.34.1/go.mod h1:yddyjq/PmAf08RMLSwDjPyCvHvYed+WjHnQxpH851LM=
-github.com/ysmood/got v0.38.2 h1:h2RYvAe5nIK+oBRMLzNIrkZaX5kjmkOBqfRMIsFzLyU=
-github.com/ysmood/got v0.38.2/go.mod h1:W7DdpuX6skL3NszLmAsC5hT7JAhuLZhByVzHTq874Qg=
+github.com/ysmood/got v0.39.4 h1:8ru7J25Zmf/sMTNYOF2172xVkjQrPMJ3R5d6uymoqL8=
+github.com/ysmood/got v0.39.4/go.mod h1:W7DdpuX6skL3NszLmAsC5hT7JAhuLZhByVzHTq874Qg=
 github.com/ysmood/gotrace v0.6.0 h1:SyI1d4jclswLhg7SWTL6os3L1WOKeNn/ZtzVQF8QmdY=
 github.com/ysmood/gotrace v0.6.0/go.mod h1:TzhIG7nHDry5//eYZDYcTzuJLYQIkykJzCRIo4/dzQM=
 github.com/ysmood/gson v0.7.3 h1:QFkWbTH8MxyUTKPkVWAENJhxqdBa4lYTQWqZCiLG6kE=

--- a/login_auto.go
+++ b/login_auto.go
@@ -54,14 +54,14 @@ func Headless(ctx context.Context, workspace, email, password string, opt ...Opt
 		Leakless(isLeaklessEnabled). // Causes false positive on Windows, see #260
 		Headless(isHeadless).
 		Devtools(false)
-	defer l.Cleanup()
 
-	url, err := l.Launch()
+	url, err := l.Context(ctx).Launch()
 	if err != nil {
 		return "", nil, ErrBrowser{Err: err, FailedTo: "launch"}
 	}
+	defer l.Cleanup()
 
-	var delay = 0 * time.Millisecond
+	var delay time.Duration = 0
 	if opts.debug {
 		delay = debugDelay
 	}

--- a/login_manual.go
+++ b/login_manual.go
@@ -26,12 +26,12 @@ func Browser(ctx context.Context, workspace string, opt ...Option) (string, []*h
 		Headless(false).             // browser window must be visible
 		Leakless(isLeaklessEnabled). // Causes false positive on Windows, see #260
 		Devtools(false)
-	defer l.Cleanup()
 
-	url, err := l.Launch()
+	url, err := l.Context(ctx).Launch()
 	if err != nil {
 		return "", nil, ErrBrowser{Err: err, FailedTo: "launch"}
 	}
+	defer l.Cleanup()
 
 	browser := rod.New().Context(ctx).ControlURL(url)
 	if err := browser.Connect(); err != nil {


### PR DESCRIPTION
If the download wasn't finished (interrupted, by SIGINT for example), so the browser hasn't launched, but we defer the Cleanup call the following happens:

all line number references are for rod@v0.114.7

1. The caller defers the Launcher.Cleanup.
1. Calls Launch().
1. The browser is being downloaded by a blocking call to getBin in Launch@launch.go:402 
1. User terminates the program by pressing ^C 
1. The Launch function hasn't made it to the line launch.go:442, so the sentinel goroutine that closes l.exit channel hasn't started
1. The deferred call never returns, because Cleanup waits for <-l.exit indefinitely.
