### PR TITLE
add path to Brave and Chromium flatpaks

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -113,6 +113,9 @@ var browserList = map[string][]LocalBrowser{
 		{bChromium, "/usr/bin/chromium-browser"},
 		{bChromium, "/snap/bin/chromium"},
 		{bChromium, "/data/data/com.termux/files/usr/bin/chromium-browser"},
+		// flatpacks
+		{bBrave, "/var/lib/flatpak/exports/bin/com.brave.Browser"},
+		{bChromium, "/var/lib/flatpak/exports/bin/org.chromium.Chromium"},
 	},
 	"openbsd": {
 		{bChrome, "chrome"},


### PR DESCRIPTION
Adds support for Brave and Chrormium flatpaks.

Note - I can not test this.

Fixes #23. (hopefully)